### PR TITLE
add middleware to allow any option to be a function

### DIFF
--- a/changelogs/2021-07-23_16-34-43.md
+++ b/changelogs/2021-07-23_16-34-43.md
@@ -1,0 +1,1 @@
+[NEW] Allow any CLI option to be a function {#62}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import { NewCommand } from "./commands/new";
 import { PrepareReleaseCommand } from "./commands/prepare-release";
 import { ValidateCommand } from "./commands/validate";
 import { getConfig } from "./config-handler";
+import { callFunctionArgs } from "./middleware/call-function-args";
 
 HandlebarsHelpers();
 
@@ -23,6 +24,9 @@ export const AllCommands: CommandModule<any, any>[] = [
 
 export const BuildCli = () => {
   const cli = yargs(hideBin(process.argv)).scriptName("yaclt");
+
+  // register middlewares
+  cli.middleware(callFunctionArgs);
 
   for (const command of AllCommands) {
     cli.command(command);

--- a/src/cli/middleware/call-function-args.ts
+++ b/src/cli/middleware/call-function-args.ts
@@ -1,0 +1,19 @@
+import yargs from "yargs";
+import { isFunction } from "../../utils/type-utils";
+
+export function callFunctionArgs(argv: Record<string, any>) {
+  for (const key of Object.keys(argv)) {
+    if (isFunction(argv[key])) {
+      try {
+        argv[key] = argv[key]();
+      } catch (error) {
+        console.error(
+          `An error occurred evaluating function argument '${key}': `,
+          error
+        );
+        yargs.exit(1, error);
+        process.exit(1);
+      }
+    }
+  }
+}

--- a/src/cli/middleware/call-function-args.ts
+++ b/src/cli/middleware/call-function-args.ts
@@ -16,4 +16,6 @@ export function callFunctionArgs(argv: Record<string, any>) {
       }
     }
   }
+
+  return argv;
 }

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -1,0 +1,8 @@
+export function isFunction(subject: unknown): subject is Function {
+  return !!(
+    subject &&
+    (subject as any).constructor &&
+    (subject as any).call &&
+    (subject as any).apply
+  );
+}

--- a/yacltrc.js
+++ b/yacltrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   branchFormat: "[a-zA-Z]/([0-9]+)-.*",
   validationPattern: "\\[.*\\]\\s+.*\\s{#[\\d]+}",
-  releaseNumber: () => require("./package.json").version.toString(),
+  releaseNumber: require("./package.json").version.toString(),
 };


### PR DESCRIPTION
Resolves #62 

Allows any option to be a function when using a Javascript config file via middleware.

## How to Test

1. Checkout this branch
2. Run `yarn build`
3. Change the `validationPattern` config in `yacltrc.js` to be a function which returns the string value
4. Run `./dist/index.js validate` -- it should report everything is valid
5. Edit the changelog in this MR to make it invalid
6. Run `./dist/index.js validate` again -- this time it should report a malformed changelog entry