### PR TITLE
add middleware to allow templates to come from files

### DIFF
--- a/changelogs/2021-07-24_14-12-38.md
+++ b/changelogs/2021-07-24_14-12-38.md
@@ -1,0 +1,1 @@
+[NEW] Add middleware to allow Handlebars template options to be filepaths to read from {#64}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,7 +8,8 @@ import { NewCommand } from "./commands/new";
 import { PrepareReleaseCommand } from "./commands/prepare-release";
 import { ValidateCommand } from "./commands/validate";
 import { getConfig } from "./config-handler";
-import { callFunctionArgs } from "./middleware/call-function-args";
+import { CallFunctionArgsMiddleware } from "./middleware/call-function-args";
+import { TemplatesFromFilesMiddleware } from "./middleware/templates-from-files";
 
 HandlebarsHelpers();
 
@@ -26,7 +27,15 @@ export const BuildCli = () => {
   const cli = yargs(hideBin(process.argv)).scriptName("yaclt");
 
   // register middlewares
-  cli.middleware(callFunctionArgs);
+  cli
+    .middleware(
+      CallFunctionArgsMiddleware.handler,
+      CallFunctionArgsMiddleware.preValidation
+    )
+    .middleware(
+      TemplatesFromFilesMiddleware.handler,
+      TemplatesFromFilesMiddleware.preValidation
+    );
 
   for (const command of AllCommands) {
     cli.command(command);

--- a/src/cli/middleware/call-function-args.ts
+++ b/src/cli/middleware/call-function-args.ts
@@ -1,21 +1,28 @@
 import yargs from "yargs";
 import { isFunction } from "../../utils/type-utils";
+import { MiddlewareHandler } from "./middleware-handler";
 
-export function callFunctionArgs(argv: Record<string, any>) {
-  for (const key of Object.keys(argv)) {
-    if (isFunction(argv[key])) {
-      try {
-        argv[key] = argv[key]();
-      } catch (error) {
-        console.error(
-          `An error occurred evaluating function argument '${key}': `,
-          error
-        );
-        yargs.exit(1, error);
-        process.exit(1);
+// Record<string, any> allows for any option set whatsoever
+export const CallFunctionArgsMiddleware: MiddlewareHandler = {
+  handler: function callFunctionArgs(
+    argv: Record<string, any>
+  ): Record<string, any> {
+    for (const key of Object.keys(argv)) {
+      if (isFunction(argv[key])) {
+        try {
+          argv[key] = argv[key]();
+        } catch (error) {
+          console.error(
+            `An error occurred evaluating function argument '${key}': `,
+            error
+          );
+          yargs.exit(1, error);
+          process.exit(1);
+        }
       }
     }
-  }
 
-  return argv;
-}
+    return argv;
+  },
+  preValidation: true,
+};

--- a/src/cli/middleware/middleware-handler.ts
+++ b/src/cli/middleware/middleware-handler.ts
@@ -1,0 +1,6 @@
+import { MiddlewareFunction } from "yargs";
+
+export interface MiddlewareHandler {
+  handler: MiddlewareFunction<Record<string, any>>;
+  preValidation: boolean;
+}

--- a/src/cli/middleware/templates-from-files.ts
+++ b/src/cli/middleware/templates-from-files.ts
@@ -1,0 +1,47 @@
+import fs from "fs";
+import { isFilepath, pathIsFile } from "../../utils/file-utils";
+import { nameof } from "../../utils/nameof";
+import { PrepareReleaseCommandOptions } from "../commands/prepare-release";
+import { GlobalArgv } from "../options";
+import { MiddlewareHandler } from "./middleware-handler";
+
+type TemplateOptions = Pick<GlobalArgv, "format"> &
+  Pick<
+    PrepareReleaseCommandOptions,
+    "changelogTemplate" | "releaseBranchPattern"
+  > &
+  Record<string, any>;
+const templateOptionKeys = [
+  nameof<TemplateOptions>("format"),
+  nameof<TemplateOptions>("changelogTemplate"),
+  nameof<TemplateOptions>("releaseBranchPattern"),
+];
+
+export const TemplatesFromFilesMiddleware: MiddlewareHandler = {
+  handler: function (argv: Record<string, any>): Record<string, any> {
+    for (const key of Object.keys(argv)) {
+      // ensure we're only manipulating options which are for handlebars templates
+      if (
+        !templateOptionKeys.some((templateKey: string) => templateKey === key)
+      ) {
+        continue;
+      }
+
+      const option = argv[key];
+      if (
+        !option ||
+        typeof option !== "string" ||
+        !isFilepath(option) ||
+        !pathIsFile(option)
+      ) {
+        continue;
+      }
+
+      const fileContents = fs.readFileSync(option).toString();
+      argv[key] = fileContents;
+    }
+
+    return argv;
+  },
+  preValidation: true,
+};

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -18,3 +18,20 @@ export const touchFile = (filePath: string): void => {
     fs.closeSync(fs.openSync(filePath, "w"));
   }
 };
+
+export const isFilepath = (subject: string): boolean => {
+  try {
+    fs.accessSync(subject);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const pathIsFile = (filePath: string): boolean => {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+};

--- a/src/utils/nameof.ts
+++ b/src/utils/nameof.ts
@@ -1,0 +1,1 @@
+export const nameof = <T>(key: keyof T): keyof T => key;


### PR DESCRIPTION
Resolves: #64 

## How to Test

1. Checkout this branch
2. Add a file `TEMPLATE.md` and add the following contents
```
TEST [{{changeType}}] {{message}} {{append "" "{"}}#{{issueId}}{{append "" "}"}}
```
3. Update `yacltrc.js` with the option `format: "./TEMPLATE.md"`
4. Run `yarn build`
5. Run `./dist/index.js --changeType NEW -m "some message"`
6. The generated changelog should start with `TEST` since it's in the template file