### PR TITLE
Use `path.resolve` to avoid module not found error for global config …

### DIFF
--- a/changelogs/2021-08-30T07-21-20.269-04-00.md
+++ b/changelogs/2021-08-30T07-21-20.269-04-00.md
@@ -1,0 +1,1 @@
+[FIXED] Use `path.resolve` to avoid module not found error for global config files {#109}

--- a/src/cli/config-handler.ts
+++ b/src/cli/config-handler.ts
@@ -36,7 +36,7 @@ const parseConfig = (
   if (configPath.endsWith(".js")) {
     // we need to require this at runtime since it's a config file
     // eslint-disable-next-line unicorn/prefer-module
-    return require(configPath.replace(".js", ""));
+    return require(path.resolve(configPath.replace(".js", "")));
   }
 
   const message = `Unsupported config format '${configPath}'. Only 'yacltrc.yaml', 'yacltrc.yml', 'yacltrc.json', and 'yacltrc.js'`;


### PR DESCRIPTION
…files

Resolves: #109 

## How to Test

1. Please leave testing instructions.
1. **Be as detailed as possible.**

## Potential Side Effects/Things to Look Out For

