### PR TITLE
Fix checking out release branch with `releaseBranchPattern` is set

### DIFF
--- a/changelogs/2021-09-01T13-14-52.288-04-00.md
+++ b/changelogs/2021-09-01T13-14-52.288-04-00.md
@@ -1,0 +1,1 @@
+[FIXED] Fix checking out release branch with `releaseBranchPattern` is set {#114}

--- a/src/actions/prepare-release/index.ts
+++ b/src/actions/prepare-release/index.ts
@@ -57,6 +57,7 @@ const actionPrepareReleaseHandler = async (
     const branchName = branchTemplate({ releaseNumber: options.releaseNumber });
     try {
       await git.branch({ fs, ref: branchName, dir: process.cwd() });
+      await git.checkout({ fs, ref: branchName, dir: process.cwd() });
     } catch {
       const message = `Failed to checkout release branch: ${branchName}`;
       Logger.error(message);


### PR DESCRIPTION
Resolves: #114 


