### PR TITLE
fixed a typo in run-actions.ts

### DIFF
--- a/changelogs/2021-09-10T22-09-11.358+05-30.md
+++ b/changelogs/2021-09-10T22-09-11.358+05-30.md
@@ -1,0 +1,3 @@
+Resolves: #132
+
+Correct the spellings of function `relativize` which was `relativeize` before. Also, update the name where the function was called.

--- a/changelogs/2021-09-10T22-09-11.358+05-30.md
+++ b/changelogs/2021-09-10T22-09-11.358+05-30.md
@@ -1,3 +1,1 @@
-Resolves: #132
-
-Correct the spellings of function `relativize` which was `relativeize` before. Also, update the name where the function was called.
+[IMPROVED] Fix typo in function name, change `relativeize` to `relativize` {#132}

--- a/src/utils/run-action.ts
+++ b/src/utils/run-action.ts
@@ -21,7 +21,7 @@ export const runAction = <T>(action: () => T): T => {
   try {
     const configPath = process.env["YACLT_CONFIG_PATH"];
     if (configPath) {
-      Logger.info(`Using configuration file at ${relativeize(configPath)}`);
+      Logger.info(`Using configuration file at ${relativize(configPath)}`);
     }
 
     return action();

--- a/src/utils/run-action.ts
+++ b/src/utils/run-action.ts
@@ -2,7 +2,7 @@ import path from "path";
 import yargs from "yargs";
 import { Logger } from "./logger";
 
-const relativeize = (configPath: string): string => {
+const relativize = (configPath: string): string => {
   const pathRelativeToCwd = path.relative(process.cwd(), configPath);
   // if config path is under current path, use path relative to cwd
   if (!pathRelativeToCwd.includes("..")) {


### PR DESCRIPTION
Resolves: #132 

## How to Test

1. Just make sure the build passes, its just renaming a function, so as long as typescript compiles we should be good

## Changelog

correct the spellings of function `relativize` which was `relativeize` before. Also, update the name where the function was called.
