### PR TITLE
Update `yacltrc.js` to allow preparing releases with a version change…

### DIFF
--- a/changelogs/2021-09-10T17-30-39.426-04-00.md
+++ b/changelogs/2021-09-10T17-30-39.426-04-00.md
@@ -1,0 +1,1 @@
+[IMPROVED] Update `yacltrc.js` to allow preparing releases with a version change in `package.json` {#148}

--- a/yacltrc.js
+++ b/yacltrc.js
@@ -36,7 +36,14 @@ module.exports = {
   },
   prePrepare: () => {
     // if work tree is not clean, can't prepare a release
-    if (execSync("git diff --stat").toString().replace(/\n/g, "").trim()) {
+    const changedFiles = execSync("git diff --stat --name-only")
+      .toString()
+      .trim();
+
+    if (
+      changedFiles.replace(/\n/g, "") !== "" &&
+      changedFiles !== "package.json"
+    ) {
       console.error(
         "Work tree is not clean. Releases can only be prepared from a clean work tree."
       );
@@ -45,7 +52,7 @@ module.exports = {
 
     if (getCurrentBranch() !== "master") {
       console.error(
-        `Releases can only be prepared from ${defaultBranch}! There should be no changes from ${defaultBranch} before preparing the changelog.`
+        `Releases can only be prepared from master! There should be no changes from master before preparing the changelog.`
       );
       return false;
     }


### PR DESCRIPTION
… in `package.json`

<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/yaclt/blob/master/CONTRIBUTING.md)!** -->

Resolves: #148 

## How to Test

1. Checkout the branch
2. Change version in `package.json`
3. Run `yaclt prepare-release -v`
4. You should get an error about not being on master but should not get an error about a dirty work tree
