### PR TITLE
#131 - changed PrepareReleaseStrategy class to an interface

### DIFF
--- a/changelogs/2021-09-14T19-26-47.533-04-00.md
+++ b/changelogs/2021-09-14T19-26-47.533-04-00.md
@@ -1,1 +1,1 @@
-[IMPROVED] Change `PrepareReleaseStrategy` class to an interface {#131}
+[IMPROVED] Change `PrepareReleaseStrategy` abstract class to an interface {#131}

--- a/changelogs/2021-09-14T19-26-47.533-04-00.md
+++ b/changelogs/2021-09-14T19-26-47.533-04-00.md
@@ -1,0 +1,1 @@
+[IMPROVED] Change `PrepareReleaseStrategy` class to an interface {#131}

--- a/src/actions/prepare-release/strategies/prepare-release-strategy.ts
+++ b/src/actions/prepare-release/strategies/prepare-release-strategy.ts
@@ -1,4 +1,4 @@
-export abstract class PrepareReleaseStrategy {
-  abstract processLine(line: string): void;
-  abstract generate(template: string, releaseNumber: string): string;
+export interface PrepareReleaseStrategy {
+  processLine(line: string): void;
+  generate(template: string, releaseNumber: string): string;
 }

--- a/src/actions/prepare-release/strategies/with-change-type.ts
+++ b/src/actions/prepare-release/strategies/with-change-type.ts
@@ -6,7 +6,7 @@ export interface EntryGroup {
   items: string[];
 }
 
-export class WithChangeTypeStrategy extends PrepareReleaseStrategy {
+export class WithChangeTypeStrategy implements PrepareReleaseStrategy {
   private entryGroups: EntryGroup[] = [];
   private changeTypeTemplate: HandlebarsTemplateDelegate<
     Record<string, unknown>
@@ -17,12 +17,11 @@ export class WithChangeTypeStrategy extends PrepareReleaseStrategy {
     changeTypeTemplate: HandlebarsTemplateDelegate<Record<string, unknown>>,
     changeTypes: string[]
   ) {
-    super();
     this.changeTypeTemplate = changeTypeTemplate;
     this.changeTypes = changeTypes;
   }
 
-  public override processLine(line: string): void {
+  public processLine(line: string): void {
     const lineChangeType: string | undefined = this.changeTypes.find(
       (changeType: string) =>
         line.includes(this.changeTypeTemplate({ changeType }))
@@ -42,7 +41,7 @@ export class WithChangeTypeStrategy extends PrepareReleaseStrategy {
     }
   }
 
-  public override generate(template: string, releaseNumber: string): string {
+  public generate(template: string, releaseNumber: string): string {
     const handlebarsTemplate = compileTemplate(template);
     return handlebarsTemplate({
       releaseNumber,

--- a/src/actions/prepare-release/strategies/without-change-type.ts
+++ b/src/actions/prepare-release/strategies/without-change-type.ts
@@ -1,14 +1,14 @@
 import { compileTemplate } from "../../../utils/template-utils";
 import { PrepareReleaseStrategy } from "./prepare-release-strategy";
 
-export class WithoutChangeTypeStrategy extends PrepareReleaseStrategy {
+export class WithoutChangeTypeStrategy implements PrepareReleaseStrategy {
   private lines: string[] = [];
 
-  public override processLine(line: string): void {
+  public processLine(line: string): void {
     this.lines.push(line);
   }
 
-  public override generate(template: string, releaseNumber: string): string {
+  public generate(template: string, releaseNumber: string): string {
     const handlebarsTemplate = compileTemplate(template);
     return handlebarsTemplate({
       releaseNumber,


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/yaclt/blob/master/CONTRIBUTING.md)!** -->

Resolves: #131 

## How to Test

1. Run `git checkout master && git pull`
2. Once you have the latest and the greatest; run `git checkout -b hsheikhali1-hsheikhali/131-change-class-to-interface`
3. Run `git pull https://github.com/hsheikhali1/yaclt.git hsheikhali/118-move-package-to-dev-deps`
4. run `yarn` to install dependencies
5. run `yarn build && ./dist/index.js new --changeType "IMPROVED"` to see if `yaclt` can still generate new changelog entries.



